### PR TITLE
Add Docker build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,61 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            rust_target: x86_64-unknown-linux-musl
+            tag: linux-amd64
+          - platform: linux/arm64
+            rust_target: aarch64-unknown-linux-musl
+            tag: linux-arm64
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push ${{ matrix.platform }}
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: scratch-final
+          push: true
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            RUST_TARGET=${{ matrix.rust_target }}
+          tags: ghcr.io/${{ github.repository }}:${{ matrix.tag }}
+
+  manifest:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create and push multi-arch manifest
+        run: |
+          docker manifest create ghcr.io/${{ github.repository }}:latest \
+            ghcr.io/${{ github.repository }}:linux-amd64 \
+            ghcr.io/${{ github.repository }}:linux-arm64
+          docker manifest push ghcr.io/${{ github.repository }}:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,13 +12,18 @@
 # -----------------------------------------------------------------
 FROM rust:bookworm AS rust-build
 
-# Get target architecture
+# Target architecture for the Rust build
 ARG RUST_TARGET
 
-RUN apt-get update && apt-get install -y --no-install-recommends pkg-config musl-tools libssl-dev
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config musl-tools libssl-dev gcc-aarch64-linux-gnu \
+    && rm -rf /var/lib/apt/lists/*
 
 # Update Rust toolchain and add necessary target
 RUN rustup update && rustup target add $RUST_TARGET
+
+# Ensure the correct C compiler is used for ARM builds
+ENV CC_aarch64_unknown_linux_musl=aarch64-linux-gnu-gcc
 
 # Set Rust compiler flags for better optimization and reproducibility
 ENV RUSTFLAGS='--remap-path-prefix $HOME=~ -C target-feature=+crt-static'


### PR DESCRIPTION
## Summary
- build and push scratch-based Docker images for amd64 and arm64
- create multi-arch manifest tagged `latest`
- add ARM toolchain to Dockerfile for arm builds

## Testing
- `cargo test --locked` *(fails: File not found /root/projects/m3u-test/settings/...)*

------
https://chatgpt.com/codex/tasks/task_e_68516beb67ec832d97bbda222b669056