### PR TITLE
Refine docker build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,10 +3,47 @@ name: Build and Push Docker Image
 on:
   push:
     branches:
-      - master
+      - dev
+    tags:
+      - 'v*'
 
 jobs:
-  build:
+  build-dev:
+    if: github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            rust_target: x86_64-unknown-linux-musl
+            tag: linux-amd64
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push ${{ matrix.platform }}
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: scratch-final
+          push: true
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            RUST_TARGET=${{ matrix.rust_target }}
+          tags: ghcr.io/${{ github.repository }}:${{ matrix.tag }}
+
+  build-release:
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -46,7 +83,8 @@ jobs:
           tags: ghcr.io/${{ github.repository }}:${{ matrix.tag }}
 
   manifest:
-    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build-release
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- build dev branch images only for AMD64
- build all architectures when tagging releases

## Testing
- `cargo test --locked` *(fails: cargo build stalled before completing)*

------
https://chatgpt.com/codex/tasks/task_e_6852a08bed60832d94dba8d488ef65e4