### PR TITLE
Fix docker manifest step

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -97,7 +97,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create and push multi-arch manifest
         run: |
-          docker manifest create ghcr.io/${{ github.repository }}:latest \
+          docker buildx imagetools create -t ghcr.io/${{ github.repository }}:latest \
             ghcr.io/${{ github.repository }}:linux-amd64 \
             ghcr.io/${{ github.repository }}:linux-arm64 \
             ghcr.io/${{ github.repository }}:linux-armv7


### PR DESCRIPTION
## Summary
- use `docker buildx imagetools create` to aggregate architecture images

## Testing
- `cargo test --locked` *(fails: processing::parser::xmltv::tests::normalize, repository::bplustree::tests::insert_test, repository::indexed_document::tests::test_read_xt)*

------
https://chatgpt.com/codex/tasks/task_e_6852a97443e4832d89903bd290a23c74