### PR TITLE
Add ARM64 runner for GitHub Actions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -54,12 +54,6 @@ jobs:
           - platform: linux/amd64
             rust_target: x86_64-unknown-linux-musl
             tag: linux-amd64
-          - platform: linux/arm64
-            rust_target: aarch64-unknown-linux-musl
-            tag: linux-arm64
-          - platform: linux/arm/v7
-            rust_target: armv7-unknown-linux-musleabihf
-            tag: linux-armv7
 
     steps:
       - uses: actions/checkout@v3
@@ -82,9 +76,46 @@ jobs:
             RUST_TARGET=${{ matrix.rust_target }}
           tags: ghcr.io/${{ github.repository }}:${{ matrix.tag }}
 
+  build-release-arm:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: buildjet-4vcpu-ubuntu-22.04-arm
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - platform: linux/arm64
+            rust_target: aarch64-unknown-linux-musl
+            tag: linux-arm64
+          - platform: linux/arm/v7
+            rust_target: armv7-unknown-linux-musleabihf
+            tag: linux-armv7
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push ${{ matrix.platform }} (arm runner)
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: scratch-final
+          push: true
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            RUST_TARGET=${{ matrix.rust_target }}
+          tags: ghcr.io/${{ github.repository }}:${{ matrix.tag }}
+
   manifest:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: build-release
+    needs: [build-release, build-release-arm]
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- extend docker-build workflow with a job that runs on an ARM64 runner
- update manifest job dependencies
- refine build matrices so amd64 builds on default runner and arm builds on arm runner

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_6852cb470e8c832dac9d8c78409f11ef