### PR TITLE
Add aarch64 build target

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,6 +19,9 @@ jobs:
           - platform: linux/amd64
             runner: ubuntu-22.04
             rust_target: x86_64-unknown-linux-musl
+          - platform: linux/aarch64
+            runner: ubuntu-22.04-arm
+            rust_target: aarch64-unknown-linux-musl
           - platform: linux/arm64
             runner: ubuntu-22.04-arm
             rust_target: aarch64-unknown-linux-musl


### PR DESCRIPTION
## Summary
- expand GitHub Actions matrix to include `linux/aarch64`

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6853ef8c3710832daeb28b45ce36e40e