### PR TITLE
Add Shadowsocks client to Docker builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -97,6 +97,12 @@ RUN apk add --no-cache tzdata \
   && ln -sf /usr/share/zoneinfo/${TZ} /output/etc/localtime
 
 
+# -----------------------------------------------------------------
+# Stage 5: Shadowsocks client (sslocal)
+# -----------------------------------------------------------------
+FROM ghcr.io/shadowsocks/sslocal-rust:latest AS sslocal   # pre-built /usr/bin/sslocal
+
+
 # =================================================================
 #
 # Part 2: Final Image Stages
@@ -166,6 +172,9 @@ COPY --from=rust-build /src/target/${RUST_TARGET}/release/tuliprox ./tuliprox
 COPY --from=node-build /app/build ./web
 COPY --from=resource-build /src/resources ./resources
 
+# Shadowsocks client
+COPY --from=sslocal /usr/bin/sslocal /usr/local/bin/sslocal
+
 ENTRYPOINT ["/app/tuliprox"]
 CMD ["-s", "-p", "/app/config"]
 
@@ -180,6 +189,9 @@ ENV TZ=${TZ}
 
 RUN apk add --no-cache bash curl ca-certificates tini
 
+# Optional Shadowsocks client
+ENV SS_CLIENT_ENABLE=0
+
 COPY --from=rust-build /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=rust-build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
@@ -191,5 +203,12 @@ COPY --from=rust-build /src/target/${RUST_TARGET}/release/tuliprox ./tuliprox
 COPY --from=node-build /app/build ./web
 COPY --from=resource-build /src/resources ./resources
 
-ENTRYPOINT ["/sbin/tini", "--", "/app/tuliprox"]
-CMD ["-s", "-p", "/app/config"]
+# Shadowsocks client
+COPY --from=sslocal /usr/bin/sslocal /usr/local/bin/sslocal
+RUN chmod +x /usr/local/bin/sslocal
+
+# Entrypoint script to optionally start sslocal
+COPY ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]
+CMD ["/app/tuliprox", "-s", "-p", "/app/config"]

--- a/docker/debug/debug-entrypoint.sh
+++ b/docker/debug/debug-entrypoint.sh
@@ -27,8 +27,13 @@ echo "    Session Ports: ${LLDB_MIN_PORT}-${LLDB_MAX_PORT}"
   --min-gdbserver-port ${LLDB_MIN_PORT} \
   --max-gdbserver-port ${LLDB_MAX_PORT} &
 
+# Optionally start Shadowsocks client in background
+if [ "$SS_CLIENT_ENABLE" = "1" ] || [ "$SS_CLIENT_ENABLE" = "true" ]; then
+  echo ">>> [debug-entrypoint] Starting sslocal client..."
+  sslocal &
+fi
+
 # --- Application Start ---
 # 3. Start the actual application in the foreground.
 #    `exec` replaces the shell process, making the application the main process.
-echo ">>> [debug-entrypoint] Starting application 'tuliprox'. Ready for debugger to attach..."
-exec /usr/src/tuliprox/target/${RUST_TARGET}/debug/tuliprox -s -p /app/config
+echo ">>> [debug-entrypoint] Starting application 'tuliprox'. Ready for debugger to attach..."exec /usr/src/tuliprox/target/${RUST_TARGET}/debug/tuliprox -s -p /app/config

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Optionally start Shadowsocks client
+if [ "$SS_CLIENT_ENABLE" = "1" ] || [ "$SS_CLIENT_ENABLE" = "true" ]; then
+  echo ">>> [entrypoint] Starting Shadowsocks client..."
+  sslocal &
+fi
+
+# Execute given command
+exec "$@"


### PR DESCRIPTION
## Summary
- add sslocal build stage for Shadowsocks client
- include sslocal in scratch and alpine final images
- start optional sslocal via entrypoint when `SS_CLIENT_ENABLE` is set

## Testing
- `cargo test` *(fails: could not compile `shared`)*

------
https://chatgpt.com/codex/tasks/task_e_686ea7d34d04832db67595ae317a9312