### PR TITLE
feat: make content security policy configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - EPG Config View
 - Fixed loading users for WebUI from user DB
 - Fixed auto EPG for batch inputs
-- ContentSecurityPolicy can be enabled
+- Content Security Policies configurable via config
 
 # 3.1.5 (2025-08-14)
 - Hot reload for config

--- a/README.md
+++ b/README.md
@@ -323,8 +323,7 @@ log:
 ### 1.10 `web_ui`
 - enabled: default is true, if set to false the web_ui is disabled
 - user_ui_enabled, true or false,  for user bouquet editor
-- content_security_policy: default false; when true, sends a Content-Security-Policy (CSP) header to help protect against cross-site scripting (XSS).
-   Not: enabling CSP may block external images/logos unless allowed via the img-src directive.
+- content-security-policies: configure Content-Security-Policy headers. When `enabled` is true, the default directives `default-src 'self'`, `script-src 'self' nonce-{nonce_b64}`, and `frame-ancestors 'none'` are applied. Additional directives can be added via `custom-attributes`. Enabling CSP may block external images/logos unless allowed via directives like `img-src`.
 - path is for web_ui path like `/ui` for reverse proxy integration if necessary.
 - auth for authentication settings
   - `enabled` can be deactivated if `enabled` is set to `false`. If not set default is `true`.
@@ -336,6 +335,19 @@ log:
 web_ui:
   enabled: true
   user_ui_enabled: true
+  content-security-policies:
+    enabled: true
+    custom-attributes:
+      - "default-src 'self'"
+      - "script-src 'self' nonce-{nonce_b64}"
+      - "frame-ancestors 'none'"
+      - "style-src 'self'"
+      - "img-src 'self' data:"
+      - "font-src 'self' data:"
+      - "connect-src 'self' wss:"
+      - "object-src 'none'"
+      - "base-uri 'self'"
+      - "form-action 'self'"
   path:
   auth:
     enabled: true

--- a/backend/src/model/config/web_ui.rs
+++ b/backend/src/model/config/web_ui.rs
@@ -1,12 +1,18 @@
 use shared::error::TuliproxError;
-use shared::model::WebUiConfigDto;
+use shared::model::{ContentSecurityPoliciesConfigDto, WebUiConfigDto};
 use crate::model::{macros, WebAuthConfig};
+
+#[derive(Debug, Clone)]
+pub struct ContentSecurityPoliciesConfig {
+    pub enabled: bool,
+    pub custom_attributes: Vec<String>,
+}
 
 #[derive(Debug, Clone)]
 pub struct WebUiConfig {
     pub enabled: bool,
     pub user_ui_enabled: bool,
-    pub content_security_policy: bool,
+    pub content_security_policies: Option<ContentSecurityPoliciesConfig>,
     pub path: Option<String>,
     pub auth: Option<WebAuthConfig>,
     pub player_server: Option<String>,
@@ -25,13 +31,25 @@ impl WebUiConfig {
     }
 }
 
+macros::from_impl!(ContentSecurityPoliciesConfig);
+impl From<&ContentSecurityPoliciesConfigDto> for ContentSecurityPoliciesConfig {
+    fn from(dto: &ContentSecurityPoliciesConfigDto) -> Self {
+        Self { enabled: dto.enabled, custom_attributes: dto.custom_attributes.clone() }
+    }
+}
+impl From<&ContentSecurityPoliciesConfig> for ContentSecurityPoliciesConfigDto {
+    fn from(instance: &ContentSecurityPoliciesConfig) -> Self {
+        Self { enabled: instance.enabled, custom_attributes: instance.custom_attributes.clone() }
+    }
+}
+
 macros::from_impl!(WebUiConfig);
 impl From<&WebUiConfigDto> for WebUiConfig {
     fn from(dto: &WebUiConfigDto) -> Self {
         Self {
             enabled: dto.enabled,
             user_ui_enabled: dto.user_ui_enabled,
-            content_security_policy: dto.content_security_policy,
+            content_security_policies: dto.content_security_policies.as_ref().map(Into::into),
             path: dto.path.clone(),
             auth: dto.auth.as_ref().map(Into::into),
             player_server: dto.player_server.clone(),
@@ -43,10 +61,11 @@ impl From<&WebUiConfig> for WebUiConfigDto {
         Self {
             enabled: instance.enabled,
             user_ui_enabled: instance.user_ui_enabled,
-            content_security_policy: instance.content_security_policy,
+            content_security_policies: instance.content_security_policies.as_ref().map(Into::into),
             path: instance.path.clone(),
             auth: instance.auth.as_ref().map(Into::into),
             player_server: instance.player_server.clone(),
         }
     }
 }
+

--- a/config/config.yml
+++ b/config/config.yml
@@ -27,6 +27,19 @@ update_on_boot: false # best not to hammer upstream during testing
 web_ui:
   enabled: true
   user_ui_enabled: true
+  content-security-policies:
+    enabled: true
+    custom-attributes:
+      - "default-src 'self'"
+      - "script-src 'self' nonce-{nonce_b64}"
+      - "frame-ancestors 'none'"
+      - "style-src 'self'"
+      - "img-src 'self' data:"
+      - "font-src 'self' data:"
+      - "connect-src 'self' wss:"
+      - "object-src 'none'"
+      - "base-uri 'self'"
+      - "form-action 'self'"
   path:
   auth:
     enabled: true

--- a/frontend/public/assets/i18n/en.json
+++ b/frontend/public/assets/i18n/en.json
@@ -244,7 +244,8 @@
     "STRIP": "Strip",
     "COPY_LINK_TULIPROX": "Copy Virtual Id",
     "COPY_LINK_PROVIDER": "Copy Provider Url",
-    "CONTENT_SECURITY_POLICY" : "Content Security Policy"
+    "CONTENT_SECURITY_POLICY" : "Content Security Policy",
+    "CUSTOM_ATTRIBUTES": "Custom Attributes"
   },
   "TABLE": {
     "EMPTY": "",

--- a/frontend/src/app/components/config/webui_config_view.rs
+++ b/frontend/src/app/components/config/webui_config_view.rs
@@ -1,8 +1,8 @@
-use crate::app::components::Card;
+use crate::app::components::{Card, Chip};
 use crate::app::context::ConfigContext;
 use crate::{
-    config_field, config_field_bool, config_field_bool_empty, config_field_empty,
-    config_field_hide, config_field_optional,
+    config_field, config_field_bool, config_field_bool_empty, config_field_child,
+    config_field_empty, config_field_hide, config_field_optional,
 };
 use yew::prelude::*;
 use yew_i18n::use_translation;
@@ -30,7 +30,14 @@ pub fn WebUiConfigView() -> Html {
            <>
             { config_field_bool_empty!(translate.t("LABEL.ENABLED")) }
             { config_field_bool_empty!(translate.t("LABEL.USER_UI_ENABLED")) }
-            { config_field_bool_empty!(translate.t("LABEL.CONTENT_SECURITY_POLICY")) }
+            { config_field_child!(translate.t("LABEL.CONTENT_SECURITY_POLICY"), {
+                html! {
+                    <>
+                        { config_field_bool_empty!(translate.t("LABEL.ENABLED")) }
+                        { config_field_empty!(translate.t("LABEL.CUSTOM_ATTRIBUTES")) }
+                    </>
+                }
+            }) }
             { config_field_empty!(translate.t("LABEL.PATH")) }
             { config_field_empty!(translate.t("LABEL.PLAYER_SERVER")) }
             { render_empty_auth()}
@@ -48,7 +55,26 @@ pub fn WebUiConfigView() -> Html {
                         <>
                             { config_field_bool!(web_ui, translate.t("LABEL.ENABLED"), enabled) }
                             { config_field_bool!(web_ui, translate.t("LABEL.USER_UI_ENABLED"), user_ui_enabled) }
-                            { config_field_bool!(web_ui, translate.t("LABEL.CONTENT_SECURITY_POLICY"), content_security_policy) }
+                            { config_field_child!(translate.t("LABEL.CONTENT_SECURITY_POLICY"), {
+                                html! {
+                                    match web_ui.content_security_policies.as_ref() {
+                                        Some(csp) => html! {
+                                            <>
+                                                { config_field_bool!(csp, translate.t("LABEL.ENABLED"), enabled) }
+                                                { config_field_child!(translate.t("LABEL.CUSTOM_ATTRIBUTES"), {
+                                                    html! { <div class="tp__config-view__tags">{ for csp.custom_attributes.iter().map(|a| html! { <Chip label={a.clone()} /> }) }</div> }
+                                                }) }
+                                            </>
+                                        },
+                                        None => html! {
+                                            <>
+                                                { config_field_bool_empty!(translate.t("LABEL.ENABLED")) }
+                                                { config_field_empty!(translate.t("LABEL.CUSTOM_ATTRIBUTES")) }
+                                            </>
+                                        }
+                                    }
+                                }
+                            }) }
                             { config_field_optional!(web_ui, translate.t("LABEL.PATH"), path) }
                             { config_field_optional!(web_ui, translate.t("LABEL.PLAYER_SERVER"), player_server) }
                             <Card>


### PR DESCRIPTION
## Summary
- allow configuring Content Security Policy via `content-security-policies` section
- show CSP configuration in Web UI
- document CSP options and update default config

## Testing
- `cargo clippy`

------
https://chatgpt.com/codex/tasks/task_e_68a2fe552f6c832d98aa7da8205c0159