### PR TITLE
feat: add configurable content security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,8 +323,7 @@ log:
 ### 1.10 `web_ui`
 - enabled: default is true, if set to false the web_ui is disabled
 - user_ui_enabled, true or false,  for user bouquet editor
-- content_security_policy: default false; when true, sends a Content-Security-Policy (CSP) header to help protect against cross-site scripting (XSS).
-   Not: enabling CSP may block external images/logos unless allowed via the img-src directive.
+- content_security_policy: configure Content-Security-Policy (CSP) headers. When `enabled` is true and no `custom_attributes` are supplied, the default directives `default-src 'self'`, `script-src 'self' nonce-{nonce_b64}` and `frame-ancestors 'none'` are used. Additional directives can be provided via `custom_attributes`.
 - path is for web_ui path like `/ui` for reverse proxy integration if necessary.
 - auth for authentication settings
   - `enabled` can be deactivated if `enabled` is set to `false`. If not set default is `true`.

--- a/backend/src/model/config/web_ui.rs
+++ b/backend/src/model/config/web_ui.rs
@@ -1,12 +1,18 @@
 use shared::error::TuliproxError;
-use shared::model::WebUiConfigDto;
+use shared::model::{ContentSecurityPolicyDto, WebUiConfigDto};
 use crate::model::{macros, WebAuthConfig};
+
+#[derive(Debug, Clone, Default)]
+pub struct ContentSecurityPolicyConfig {
+    pub enabled: bool,
+    pub custom_attributes: Vec<String>,
+}
 
 #[derive(Debug, Clone)]
 pub struct WebUiConfig {
     pub enabled: bool,
     pub user_ui_enabled: bool,
-    pub content_security_policy: bool,
+    pub content_security_policy: Option<ContentSecurityPolicyConfig>,
     pub path: Option<String>,
     pub auth: Option<WebAuthConfig>,
     pub player_server: Option<String>,
@@ -26,24 +32,44 @@ impl WebUiConfig {
 }
 
 macros::from_impl!(WebUiConfig);
+
+impl From<&ContentSecurityPolicyDto> for ContentSecurityPolicyConfig {
+    fn from(dto: &ContentSecurityPolicyDto) -> Self {
+        Self {
+            enabled: dto.enabled,
+            custom_attributes: dto.custom_attributes.clone(),
+        }
+    }
+}
+
+impl From<&ContentSecurityPolicyConfig> for ContentSecurityPolicyDto {
+    fn from(instance: &ContentSecurityPolicyConfig) -> Self {
+        Self {
+            enabled: instance.enabled,
+            custom_attributes: instance.custom_attributes.clone(),
+        }
+    }
+}
+
 impl From<&WebUiConfigDto> for WebUiConfig {
     fn from(dto: &WebUiConfigDto) -> Self {
         Self {
             enabled: dto.enabled,
             user_ui_enabled: dto.user_ui_enabled,
-            content_security_policy: dto.content_security_policy,
+            content_security_policy: dto.content_security_policy.as_ref().map(Into::into),
             path: dto.path.clone(),
             auth: dto.auth.as_ref().map(Into::into),
             player_server: dto.player_server.clone(),
         }
     }
 }
+
 impl From<&WebUiConfig> for WebUiConfigDto {
     fn from(instance: &WebUiConfig) -> Self {
         Self {
             enabled: instance.enabled,
             user_ui_enabled: instance.user_ui_enabled,
-            content_security_policy: instance.content_security_policy,
+            content_security_policy: instance.content_security_policy.as_ref().map(Into::into),
             path: instance.path.clone(),
             auth: instance.auth.as_ref().map(Into::into),
             player_server: instance.player_server.clone(),

--- a/config/config.yml
+++ b/config/config.yml
@@ -27,7 +27,20 @@ update_on_boot: false # best not to hammer upstream during testing
 web_ui:
   enabled: true
   user_ui_enabled: true
-  path:
+    path:
+    content_security_policy:
+      enabled: true
+      custom_attributes:
+        - "default-src 'self'"                    # default value
+        - "script-src 'self' nonce-{nonce_b64}"   # default value
+        - "frame-ancestors 'none'"                # default value
+        - "style-src 'self'"
+        - "img-src 'self' data:"
+        - "font-src 'self' data:"
+        - "connect-src 'self' wss:"
+        - "object-src 'none'"
+        - "base-uri 'self'"
+        - "form-action 'self'"
   auth:
     enabled: true
     issuer: tuliprox

--- a/frontend/public/assets/i18n/en.json
+++ b/frontend/public/assets/i18n/en.json
@@ -244,7 +244,8 @@
     "STRIP": "Strip",
     "COPY_LINK_TULIPROX": "Copy Virtual Id",
     "COPY_LINK_PROVIDER": "Copy Provider Url",
-    "CONTENT_SECURITY_POLICY" : "Content Security Policy"
+    "CONTENT_SECURITY_POLICY" : "Content Security Policy",
+    "CUSTOM_ATTRIBUTES": "Custom Attributes"
   },
   "TABLE": {
     "EMPTY": "",

--- a/frontend/src/app/components/config/webui_config_view.rs
+++ b/frontend/src/app/components/config/webui_config_view.rs
@@ -1,8 +1,8 @@
-use crate::app::components::Card;
+use crate::app::components::{Card, Chip};
 use crate::app::context::ConfigContext;
 use crate::{
-    config_field, config_field_bool, config_field_bool_empty, config_field_empty,
-    config_field_hide, config_field_optional,
+    config_field, config_field_bool, config_field_bool_empty, config_field_child,
+    config_field_empty, config_field_hide, config_field_optional,
 };
 use yew::prelude::*;
 use yew_i18n::use_translation;
@@ -25,15 +25,25 @@ pub fn WebUiConfigView() -> Html {
         }
     };
 
+    let render_empty_csp = || {
+        html! {
+        <Card>
+            <h1>{translate.t("LABEL.CONTENT_SECURITY_POLICY")}</h1>
+                { config_field_bool_empty!(translate.t("LABEL.ENABLED")) }
+                { config_field_empty!(translate.t("LABEL.CUSTOM_ATTRIBUTES")) }
+        </Card>
+        }
+    };
+
     let render_empty = || {
         html! {
            <>
             { config_field_bool_empty!(translate.t("LABEL.ENABLED")) }
             { config_field_bool_empty!(translate.t("LABEL.USER_UI_ENABLED")) }
-            { config_field_bool_empty!(translate.t("LABEL.CONTENT_SECURITY_POLICY")) }
             { config_field_empty!(translate.t("LABEL.PATH")) }
             { config_field_empty!(translate.t("LABEL.PLAYER_SERVER")) }
-            { render_empty_auth()}
+            { render_empty_csp() }
+            { render_empty_auth() }
             </>
         }
     };
@@ -48,9 +58,22 @@ pub fn WebUiConfigView() -> Html {
                         <>
                             { config_field_bool!(web_ui, translate.t("LABEL.ENABLED"), enabled) }
                             { config_field_bool!(web_ui, translate.t("LABEL.USER_UI_ENABLED"), user_ui_enabled) }
-                            { config_field_bool!(web_ui, translate.t("LABEL.CONTENT_SECURITY_POLICY"), content_security_policy) }
                             { config_field_optional!(web_ui, translate.t("LABEL.PATH"), path) }
                             { config_field_optional!(web_ui, translate.t("LABEL.PLAYER_SERVER"), player_server) }
+                            {
+                                match web_ui.content_security_policy.as_ref() {
+                                    Some(csp) => html! {
+                                        <Card>
+                                            <h1>{translate.t("LABEL.CONTENT_SECURITY_POLICY")}</h1>
+                                            { config_field_bool!(csp, translate.t("LABEL.ENABLED"), enabled) }
+                                            { config_field_child!(translate.t("LABEL.CUSTOM_ATTRIBUTES"), {
+                                                html! { <div class="tp__config-view__tags">{ for csp.custom_attributes.iter().map(|a| html!{ <Chip label={a.clone()} /> }) }</div> }
+                                            }) }
+                                        </Card>
+                                    },
+                                    None => render_empty_csp(),
+                                }
+                            }
                             <Card>
                               <h1>{translate.t("LABEL.AUTH")}</h1>
                               {

--- a/shared/src/model/config/web_ui.rs
+++ b/shared/src/model/config/web_ui.rs
@@ -1,6 +1,6 @@
 use crate::error::{TuliproxError, TuliproxErrorKind};
 use crate::model::WebAuthConfigDto;
-use crate::utils::{default_as_true};
+use crate::utils::default_as_true;
 
 const RESERVED_PATHS: &[&str] = &[
     "live", "movie", "series", "m3u-stream", "healthcheck", "status",
@@ -11,13 +11,22 @@ const RESERVED_PATHS: &[&str] = &[
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default, PartialEq)]
 #[serde(deny_unknown_fields)]
+pub struct ContentSecurityPolicyDto {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub custom_attributes: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct WebUiConfigDto {
     #[serde(default = "default_as_true")]
     pub enabled: bool,
     #[serde(default = "default_as_true")]
     pub user_ui_enabled: bool,
-    #[serde(default)]
-    pub content_security_policy: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_security_policy: Option<ContentSecurityPolicyDto>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -30,6 +39,7 @@ impl WebUiConfigDto {
     pub fn prepare(&mut self) -> Result<(), TuliproxError> {
         if !self.enabled {
             self.auth = None;
+            self.content_security_policy = None;
         }
 
         if let Some(web_ui_path) = self.path.as_ref() {


### PR DESCRIPTION
## Summary
- allow configuring CSP directives via `content_security_policy` section
- expose custom CSP attributes in the web UI
- build response headers from default + configured CSP entries

## Testing
- `cargo clippy`