### PR TITLE
Add configurable removal of custom X headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 # 3.1.7 (2025-09-xx)
 - Added Dark / Bright theme switch
+- Added `remove_x_header` option for reverse proxy to strip custom `X-` headers (default: false)
 
 # 3.1.6 (2025-09-01)
 - EPG Config View added

--- a/README.md
+++ b/README.md
@@ -297,6 +297,15 @@ reverse_proxy:
   disable_referer_header: false
 ```
 
+#### 1.6.6 `remove_x_header`
+If set to `true`, request headers starting with `x` are removed before forwarding.
+Default value is `false`.
+
+```yaml
+reverse_proxy:
+  remove_x_header: true
+```
+
 ### 1.7 `backup_dir`
 is the directory where the backup configuration files written, when saved from the ui.
 

--- a/backend/src/model/config/base.rs
+++ b/backend/src/model/config/base.rs
@@ -4,7 +4,7 @@ use log::{error, info};
 use path_clean::PathClean;
 use shared::error::{TuliproxError};
 use shared::model::{ConfigDto, HdHomeRunDeviceOverview};
-use shared::utils::set_sanitize_sensitive_info;
+use shared::utils::{set_remove_x_header, set_sanitize_sensitive_info};
 use crate::model::{macros, ConfigApi, ReverseProxyConfig, ScheduleConfig};
 use crate::model::{HdHomeRunConfig, IpCheckConfig, LogConfig, MessagingConfig, ProxyConfig, VideoConfig, WebUiConfig};
 use crate::{utils};
@@ -103,6 +103,8 @@ impl Config {
 
     pub fn update_runtime(&self) {
         set_sanitize_sensitive_info(self.log.as_ref().is_none_or(|l| l.sanitize_sensitive_info));
+        let remove_x_header = self.reverse_proxy.as_ref().map_or(false, |r| r.remove_x_header);
+        set_remove_x_header(remove_x_header);
         let temp_path = PathBuf::from(&self.working_dir).join("tmp");
         create_directories(self, &temp_path);
         let _ = tempfile::env::override_temp_dir(&temp_path);

--- a/backend/src/model/config/reverse_proxy.rs
+++ b/backend/src/model/config/reverse_proxy.rs
@@ -6,6 +6,7 @@ use crate::model::{macros, RateLimitConfig, StreamConfig};
 pub struct ReverseProxyConfig {
     pub resource_rewrite_disabled: bool,
     pub disable_referer_header: bool,
+    pub remove_x_header: bool,
     pub stream: Option<StreamConfig>,
     pub cache: Option<CacheConfig>,
     pub rate_limit: Option<RateLimitConfig>,
@@ -18,6 +19,7 @@ impl From<&ReverseProxyConfigDto> for ReverseProxyConfig {
         Self {
             resource_rewrite_disabled: dto.resource_rewrite_disabled,
             disable_referer_header: dto.disable_referer_header,
+            remove_x_header: dto.remove_x_header,
             stream: dto.stream.as_ref().map(Into::into),
             cache: dto.cache.as_ref().map(Into::into),
             rate_limit: dto.rate_limit.as_ref().map(Into::into),
@@ -30,6 +32,7 @@ impl From<&ReverseProxyConfig> for ReverseProxyConfigDto {
         Self {
             resource_rewrite_disabled: instance.resource_rewrite_disabled,
             disable_referer_header: instance.disable_referer_header,
+            remove_x_header: instance.remove_x_header,
             stream: instance.stream.as_ref().map(Into::into),
             cache: instance.cache.as_ref().map(Into::into),
             rate_limit: instance.rate_limit.as_ref().map(Into::into),

--- a/config/config.yml
+++ b/config/config.yml
@@ -22,6 +22,9 @@ log:
   log_active_user: true
   log_level: debug
 
+reverse_proxy:
+  remove_x_header: true
+
 update_on_boot: false # best not to hammer upstream during testing
 
 web_ui:

--- a/frontend/public/assets/i18n/en.json
+++ b/frontend/public/assets/i18n/en.json
@@ -40,6 +40,7 @@
     "ACTIVE_USER": "Active User",
     "RESOURCE_REWRITE_DISABLE": "Resource Rewrite disable",
     "DISABLE_REFERER_HEADER": "Referer header disable",
+    "REMOVE_X_HEADER": "Remove X headers",
     "RECONNECT": "Reconnect",
     "THROTTLE": "Throttle",
     "GRACE_PERIOD": "Grace period ms",
@@ -361,6 +362,7 @@
       "PROXY": {
         "RESOURCE_REWRITE_DISABLE": "If activated, the URL rewrite of resources in reverse proxy mode is disabled",
         "DISABLE_REFERER_HEADER": "If activated, the referer header is not sent to the provider",
+        "REMOVE_X_HEADER": "If activated, request headers starting with 'x' are dropped",
         "THROTTLE": "Supported units are KB/s,MB/s,KiB/s,MiB/s,kbps,mbps,Mibps"
       },
       "WEB_UI": {

--- a/frontend/src/app/components/config/reverse_proxy_config_view.rs
+++ b/frontend/src/app/components/config/reverse_proxy_config_view.rs
@@ -1,15 +1,15 @@
-use yew::prelude::*;
-use yew_i18n::use_translation;
-use shared::model::{
-    CacheConfigDto, RateLimitConfigDto, StreamConfigDto, ReverseProxyConfigDto,
-};
-use crate::app::context::ConfigContext;
-use crate::app::components::config::config_view_context::ConfigViewContext;
 use crate::app::components::config::config_page::ConfigForm;
+use crate::app::components::config::config_view_context::ConfigViewContext;
 use crate::app::components::config::macros::HasFormData;
 use crate::app::components::Card;
-use crate::{config_field, config_field_bool, config_field_optional,
-            edit_field_bool, edit_field_number, edit_field_number_u64, edit_field_text_option, generate_form_reducer};
+use crate::app::context::ConfigContext;
+use crate::{
+    config_field, config_field_bool, config_field_optional, edit_field_bool, edit_field_number,
+    edit_field_number_u64, edit_field_text_option, generate_form_reducer,
+};
+use shared::model::{CacheConfigDto, RateLimitConfigDto, ReverseProxyConfigDto, StreamConfigDto};
+use yew::prelude::*;
+use yew_i18n::use_translation;
 
 const LABEL_CACHE: &str = "LABEL.CACHE";
 const LABEL_ENABLED: &str = "LABEL.ENABLED";
@@ -30,6 +30,7 @@ const LABEL_BURST_SIZE: &str = "LABEL.BURST_SIZE";
 
 const LABEL_RESOURCE_REWRITE_DISABLED: &str = "LABEL.RESOURCE_REWRITE_DISABLED";
 const LABEL_DISABLE_REFERER_HEADER: &str = "LABEL.DISABLE_REFERER_HEADER";
+const LABEL_REMOVE_X_HEADER: &str = "LABEL.REMOVE_X_HEADER";
 
 generate_form_reducer!(
     state: CacheConfigFormState { form: CacheConfigDto },
@@ -70,6 +71,7 @@ generate_form_reducer!(
     fields {
         ResourceRewriteDisabled => resource_rewrite_disabled: bool,
         DisableRefererHeader => disable_referer_header: bool,
+        RemoveXHeader => remove_x_header: bool,
     }
 );
 
@@ -79,18 +81,26 @@ pub fn ReverseProxyConfigView() -> Html {
     let config_ctx = use_context::<ConfigContext>().expect("ConfigContext not found");
     let config_view_ctx = use_context::<ConfigViewContext>().expect("ConfigViewContext not found");
 
-    let reverse_proxy_state: UseReducerHandle<ReverseProxyConfigFormState> = use_reducer(|| {
-        ReverseProxyConfigFormState { form: ReverseProxyConfigDto::default(), modified: false }
-    });
-    let cache_state: UseReducerHandle<CacheConfigFormState> = use_reducer(|| {
-        CacheConfigFormState { form: CacheConfigDto::default(), modified: false }
-    });
-    let rate_limit_state: UseReducerHandle<RateLimitConfigFormState> = use_reducer(|| {
-        RateLimitConfigFormState { form: RateLimitConfigDto::default(), modified: false }
-    });
-    let stream_state: UseReducerHandle<StreamConfigFormState> = use_reducer(|| {
-        StreamConfigFormState { form: StreamConfigDto::default(), modified: false }
-    });
+    let reverse_proxy_state: UseReducerHandle<ReverseProxyConfigFormState> =
+        use_reducer(|| ReverseProxyConfigFormState {
+            form: ReverseProxyConfigDto::default(),
+            modified: false,
+        });
+    let cache_state: UseReducerHandle<CacheConfigFormState> =
+        use_reducer(|| CacheConfigFormState {
+            form: CacheConfigDto::default(),
+            modified: false,
+        });
+    let rate_limit_state: UseReducerHandle<RateLimitConfigFormState> =
+        use_reducer(|| RateLimitConfigFormState {
+            form: RateLimitConfigDto::default(),
+            modified: false,
+        });
+    let stream_state: UseReducerHandle<StreamConfigFormState> =
+        use_reducer(|| StreamConfigFormState {
+            form: StreamConfigDto::default(),
+            modified: false,
+        });
 
     {
         let on_form_change = config_view_ctx.on_form_change.clone();
@@ -100,7 +110,12 @@ pub fn ReverseProxyConfigView() -> Html {
         let stream_state = stream_state.clone();
 
         use_effect_with(
-            (reverse_proxy_state, cache_state, rate_limit_state, stream_state),
+            (
+                reverse_proxy_state,
+                cache_state,
+                rate_limit_state,
+                stream_state,
+            ),
             move |(rp, cache, rl, stream)| {
                 let mut form = rp.form.clone();
                 form.cache = Some(cache.form.clone());
@@ -119,21 +134,45 @@ pub fn ReverseProxyConfigView() -> Html {
         let rate_limit_state = rate_limit_state.clone();
         let stream_state = stream_state.clone();
 
-        let reverse_proxy_cfg = config_ctx.config.as_ref().and_then(|c| c.config.reverse_proxy.clone());
-        use_effect_with((reverse_proxy_cfg, config_view_ctx.edit_mode.clone()), move |(cfg, _mode)| {
-            if let Some(rp) = cfg {
-                reverse_proxy_state.dispatch(ReverseProxyConfigFormAction::SetAll((*rp).clone()));
-                cache_state.dispatch(CacheConfigFormAction::SetAll(rp.cache.as_ref().map_or_else(CacheConfigDto::default, |c| c.clone())));
-                rate_limit_state.dispatch(RateLimitConfigFormAction::SetAll(rp.rate_limit.as_ref().map_or_else(RateLimitConfigDto::default, |rl| rl.clone())));
-                stream_state.dispatch(StreamConfigFormAction::SetAll(rp.stream.as_ref().map_or_else(StreamConfigDto::default, |s| s.clone())));
-            } else {
-                reverse_proxy_state.dispatch(ReverseProxyConfigFormAction::SetAll(ReverseProxyConfigDto::default()));
-                cache_state.dispatch(CacheConfigFormAction::SetAll(CacheConfigDto::default()));
-                rate_limit_state.dispatch(RateLimitConfigFormAction::SetAll(RateLimitConfigDto::default()));
-                stream_state.dispatch(StreamConfigFormAction::SetAll(StreamConfigDto::default()));
-            }
-            || ()
-        });
+        let reverse_proxy_cfg = config_ctx
+            .config
+            .as_ref()
+            .and_then(|c| c.config.reverse_proxy.clone());
+        use_effect_with(
+            (reverse_proxy_cfg, config_view_ctx.edit_mode.clone()),
+            move |(cfg, _mode)| {
+                if let Some(rp) = cfg {
+                    reverse_proxy_state
+                        .dispatch(ReverseProxyConfigFormAction::SetAll((*rp).clone()));
+                    cache_state.dispatch(CacheConfigFormAction::SetAll(
+                        rp.cache
+                            .as_ref()
+                            .map_or_else(CacheConfigDto::default, |c| c.clone()),
+                    ));
+                    rate_limit_state.dispatch(RateLimitConfigFormAction::SetAll(
+                        rp.rate_limit
+                            .as_ref()
+                            .map_or_else(RateLimitConfigDto::default, |rl| rl.clone()),
+                    ));
+                    stream_state.dispatch(StreamConfigFormAction::SetAll(
+                        rp.stream
+                            .as_ref()
+                            .map_or_else(StreamConfigDto::default, |s| s.clone()),
+                    ));
+                } else {
+                    reverse_proxy_state.dispatch(ReverseProxyConfigFormAction::SetAll(
+                        ReverseProxyConfigDto::default(),
+                    ));
+                    cache_state.dispatch(CacheConfigFormAction::SetAll(CacheConfigDto::default()));
+                    rate_limit_state.dispatch(RateLimitConfigFormAction::SetAll(
+                        RateLimitConfigDto::default(),
+                    ));
+                    stream_state
+                        .dispatch(StreamConfigFormAction::SetAll(StreamConfigDto::default()));
+                }
+                || ()
+            },
+        );
     }
 
     let render_cache = || {
@@ -172,11 +211,12 @@ pub fn ReverseProxyConfigView() -> Html {
     };
 
     let render_view_mode = || {
-       html! {
+        html! {
             <>
               <div class="tp__reverse-proxy-config-view__header tp__config-view-page__header">
                 { config_field_bool!(reverse_proxy_state.form, translate.t(LABEL_RESOURCE_REWRITE_DISABLED), resource_rewrite_disabled) }
                 { config_field_bool!(reverse_proxy_state.form, translate.t(LABEL_DISABLE_REFERER_HEADER), disable_referer_header) }
+                { config_field_bool!(reverse_proxy_state.form, translate.t(LABEL_REMOVE_X_HEADER), remove_x_header) }
               </div>
               <div class="tp__reverse-proxy-config-view__body tp__config-view-page__body">
                 { render_cache() }
@@ -187,36 +227,39 @@ pub fn ReverseProxyConfigView() -> Html {
         }
     };
 
-    let render_edit_mode = || html! {
-        <>
-          <div class="tp__reverse-proxy-config-view__header tp__config-view-page__header">
-            { edit_field_bool!(reverse_proxy_state, translate.t(LABEL_RESOURCE_REWRITE_DISABLED), resource_rewrite_disabled, ReverseProxyConfigFormAction::ResourceRewriteDisabled) }
-            { edit_field_bool!(reverse_proxy_state, translate.t(LABEL_DISABLE_REFERER_HEADER), disable_referer_header, ReverseProxyConfigFormAction::DisableRefererHeader) }
-          </div>
-          <div class="tp__reverse-proxy-config-view__body tp__config-view-page__body">
-            <Card class="tp__config-view__card">
-                <h1>{translate.t(LABEL_CACHE)}</h1>
-                { edit_field_bool!(cache_state, translate.t(LABEL_ENABLED), enabled, CacheConfigFormAction::Enabled) }
-                { edit_field_text_option!(cache_state, translate.t(LABEL_SIZE), size, CacheConfigFormAction::Size) }
-                { edit_field_text_option!(cache_state, translate.t(LABEL_DIRECTORY), dir, CacheConfigFormAction::Dir) }
-            </Card>
-            <Card class="tp__config-view__card">
-                <h1>{translate.t(LABEL_RATE_LIMIT)}</h1>
-                { edit_field_bool!(rate_limit_state, translate.t(LABEL_ENABLED), enabled, RateLimitConfigFormAction::Enabled) }
-                { edit_field_number_u64!(rate_limit_state, translate.t(LABEL_PERIOD_MILLIS), period_millis, RateLimitConfigFormAction::PeriodMillis) }
-                { edit_field_number!(rate_limit_state, translate.t(LABEL_BURST_SIZE), burst_size, RateLimitConfigFormAction::BurstSize) }
-            </Card>
-            <Card class="tp__config-view__card">
-                <h1>{translate.t(LABEL_STREAM)}</h1>
-                { edit_field_bool!(stream_state, translate.t(LABEL_RETRY), retry, StreamConfigFormAction::Retry) }
-                { edit_field_text_option!(stream_state, translate.t(LABEL_THROTTLE), throttle, StreamConfigFormAction::Throttle) }
-                { edit_field_number_u64!(stream_state, translate.t(LABEL_GRACE_PERIOD_MILLIS), grace_period_millis, StreamConfigFormAction::GracePeriodMillis) }
-                { edit_field_number_u64!(stream_state, translate.t(LABEL_GRACE_PERIOD_TIMEOUT_SECS), grace_period_timeout_secs, StreamConfigFormAction::GracePeriodTimeoutSecs) }
-                { edit_field_number!(stream_state, translate.t(LABEL_FORCED_RETRY_INTERVAL_SECS), forced_retry_interval_secs, StreamConfigFormAction::ForcedRetryIntervalSecs) }
-                { edit_field_number_u64!(stream_state, translate.t(LABEL_THROTTLE_KBPS), throttle_kbps, StreamConfigFormAction::ThrottleKbps) }
-            </Card>
-          </div>
-        </>
+    let render_edit_mode = || {
+        html! {
+            <>
+              <div class="tp__reverse-proxy-config-view__header tp__config-view-page__header">
+                { edit_field_bool!(reverse_proxy_state, translate.t(LABEL_RESOURCE_REWRITE_DISABLED), resource_rewrite_disabled, ReverseProxyConfigFormAction::ResourceRewriteDisabled) }
+                { edit_field_bool!(reverse_proxy_state, translate.t(LABEL_DISABLE_REFERER_HEADER), disable_referer_header, ReverseProxyConfigFormAction::DisableRefererHeader) }
+                { edit_field_bool!(reverse_proxy_state, translate.t(LABEL_REMOVE_X_HEADER), remove_x_header, ReverseProxyConfigFormAction::RemoveXHeader) }
+              </div>
+              <div class="tp__reverse-proxy-config-view__body tp__config-view-page__body">
+                <Card class="tp__config-view__card">
+                    <h1>{translate.t(LABEL_CACHE)}</h1>
+                    { edit_field_bool!(cache_state, translate.t(LABEL_ENABLED), enabled, CacheConfigFormAction::Enabled) }
+                    { edit_field_text_option!(cache_state, translate.t(LABEL_SIZE), size, CacheConfigFormAction::Size) }
+                    { edit_field_text_option!(cache_state, translate.t(LABEL_DIRECTORY), dir, CacheConfigFormAction::Dir) }
+                </Card>
+                <Card class="tp__config-view__card">
+                    <h1>{translate.t(LABEL_RATE_LIMIT)}</h1>
+                    { edit_field_bool!(rate_limit_state, translate.t(LABEL_ENABLED), enabled, RateLimitConfigFormAction::Enabled) }
+                    { edit_field_number_u64!(rate_limit_state, translate.t(LABEL_PERIOD_MILLIS), period_millis, RateLimitConfigFormAction::PeriodMillis) }
+                    { edit_field_number!(rate_limit_state, translate.t(LABEL_BURST_SIZE), burst_size, RateLimitConfigFormAction::BurstSize) }
+                </Card>
+                <Card class="tp__config-view__card">
+                    <h1>{translate.t(LABEL_STREAM)}</h1>
+                    { edit_field_bool!(stream_state, translate.t(LABEL_RETRY), retry, StreamConfigFormAction::Retry) }
+                    { edit_field_text_option!(stream_state, translate.t(LABEL_THROTTLE), throttle, StreamConfigFormAction::Throttle) }
+                    { edit_field_number_u64!(stream_state, translate.t(LABEL_GRACE_PERIOD_MILLIS), grace_period_millis, StreamConfigFormAction::GracePeriodMillis) }
+                    { edit_field_number_u64!(stream_state, translate.t(LABEL_GRACE_PERIOD_TIMEOUT_SECS), grace_period_timeout_secs, StreamConfigFormAction::GracePeriodTimeoutSecs) }
+                    { edit_field_number!(stream_state, translate.t(LABEL_FORCED_RETRY_INTERVAL_SECS), forced_retry_interval_secs, StreamConfigFormAction::ForcedRetryIntervalSecs) }
+                    { edit_field_number_u64!(stream_state, translate.t(LABEL_THROTTLE_KBPS), throttle_kbps, StreamConfigFormAction::ThrottleKbps) }
+                </Card>
+              </div>
+            </>
+        }
     };
 
     html! {

--- a/shared/src/model/config/reverse_proxy.rs
+++ b/shared/src/model/config/reverse_proxy.rs
@@ -9,6 +9,8 @@ pub struct ReverseProxyConfigDto {
     pub resource_rewrite_disabled: bool,
     #[serde(default)]
     pub disable_referer_header: bool,
+    #[serde(default)]
+    pub remove_x_header: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stream: Option<StreamConfigDto>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -21,6 +23,7 @@ impl ReverseProxyConfigDto {
     pub fn is_empty(&self) -> bool {
         !self.resource_rewrite_disabled
             && !self.disable_referer_header
+            && !self.remove_x_header
             && (self.stream.is_none() || self.stream.as_ref().is_some_and(|s| s.is_empty()))
             && (self.cache.is_none() || self.cache.as_ref().is_some_and(|c| c.is_empty()))
             && (self.rate_limit.is_none() || self.rate_limit.as_ref().is_some_and(|r| r.is_empty()))

--- a/shared/src/utils/constants.rs
+++ b/shared/src/utils/constants.rs
@@ -1,9 +1,8 @@
 use regex::Regex;
 use std::collections::HashSet;
 use std::string::ToString;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::LazyLock;
-
 
 pub const USER_FILE: &str = "user.txt";
 pub const CONFIG_PATH: &str = "config";
@@ -12,10 +11,8 @@ pub const SOURCE_FILE: &str = "source.yml";
 pub const MAPPING_FILE: &str = "mapping.yml";
 pub const API_PROXY_FILE: &str = "api-proxy.yml";
 
-
 pub const ENCODING_GZIP: &str = "gzip";
 pub const ENCODING_DEFLATE: &str = "deflate";
-
 
 pub const HLS_EXT: &str = ".m3u8";
 pub const DASH_EXT: &str = ".mpd";
@@ -45,9 +42,8 @@ const SUPPORTED_RESPONSE_HEADERS: &[&str] = &[
     "last-modified",
     "cache-control",
     "etag",
-    "expires"
+    "expires",
 ];
-
 
 pub fn filter_response_header(key: &str) -> bool {
     SUPPORTED_RESPONSE_HEADERS.contains(&key)
@@ -55,6 +51,9 @@ pub fn filter_response_header(key: &str) -> bool {
 
 pub fn filter_request_header(key: &str) -> bool {
     if key == "host" || key == "connection" {
+        return false;
+    }
+    if CONSTANTS.remove_x_header.load(Ordering::Relaxed) && key.starts_with('x') {
         return false;
     }
     true
@@ -90,14 +89,15 @@ pub struct Constants {
     pub re_whitespace: Regex,
     pub re_hls_uri: Regex,
     pub sanitize: AtomicBool,
+    pub remove_x_header: AtomicBool,
     pub export_style_config: ExportStyleConfig,
     pub country_codes: HashSet<&'static str>,
     pub allowed_output_formats: Vec<String>,
-    pub re_trakt_year:  Regex,
-    pub re_quality:  Regex,
+    pub re_trakt_year: Regex,
+    pub re_quality: Regex,
 }
 
-pub static CONSTANTS: LazyLock<Constants> = LazyLock::new(||
+pub static CONSTANTS: LazyLock<Constants> = LazyLock::new(|| {
     Constants {
         re_credentials: Regex::new(r"((username|password|token)=)[^&]*").unwrap(),
         re_ipv4: Regex::new(r"\b((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\b").unwrap(),
@@ -118,8 +118,8 @@ pub static CONSTANTS: LazyLock<Constants> = LazyLock::new(||
         re_remove_filename_ending: Regex::new(r"[_.\s-]$").unwrap(),
         re_whitespace: Regex::new(r"\s+").unwrap(),
         re_hls_uri: Regex::new(r#"URI="([^"]+)""#).unwrap(),
-
         sanitize: AtomicBool::new(true),
+        remove_x_header: AtomicBool::new(false),
         export_style_config: ExportStyleConfig {
             season: Regex::new(r"[Ss]\d{1,2}").unwrap(),
             episode: Regex::new(r"[Ee]\d{1,2}").unwrap(),
@@ -146,4 +146,4 @@ pub static CONSTANTS: LazyLock<Constants> = LazyLock::new(||
         re_trakt_year: Regex::new(r"\(?(\d{4})\)?$").unwrap(),
         re_quality: Regex::new(r"(?i)\b(4K|UHD|8K|2160p?|1080p?|720p?|480p?|BLURAY|HDTV|DVDRIP|CAM|TS|HDR|DV|SDR)\b").unwrap(),
     }
-);
+});


### PR DESCRIPTION
## Summary
- allow reverse proxy to strip custom `X-*` headers; default is now `false`
- wire config flag through backend and shared runtime
- document `remove_x_header` option and provide sample config

## Testing
- `cargo test --workspace --no-run` *(fails: mismatched types in active_provider_manager.rs)*
- `rustc /tmp/test.rs -O && ./test` *(prints `true` then `false` verifying header filtering)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfa0b2c5c832daa17de1ab85e1dc1