### PR TITLE
Fix build failure caused by dependency updates

### DIFF
--- a/backend/src/api/endpoints/web_index.rs
+++ b/backend/src/api/endpoints/web_index.rs
@@ -5,8 +5,6 @@ use crate::auth::{create_jwt_admin, create_jwt_user, is_admin, verify_password, 
 use axum::body::Body;
 use axum::http::Request;
 use axum::response::IntoResponse;
-use axum::{routing::get, Json, Router};
-use base64::engine::general_purpose::STANDARD as B64_STD;
 use base64::Engine;
 use lol_html::{element, RewriteStrSettings};
 use log::error;

--- a/backend/src/api/main_api.rs
+++ b/backend/src/api/main_api.rs
@@ -342,7 +342,7 @@ fn add_rate_limiter(
             .burst_size(rate_limit_cfg.burst_size)
             .finish();
         if let Some(config) = governor_conf {
-            router.layer(tower_governor::GovernorLayer::new(Arc::new(config)))
+            router.layer(tower_governor::GovernorLayer { config: Arc::new(config) })
         } else {
             error!("Failed to initialize rate limiter");
             router

--- a/backend/src/processing/parser/xmltv.rs
+++ b/backend/src/processing/parser/xmltv.rs
@@ -384,7 +384,7 @@ where
 
 fn handle_text_tag(stack: &mut [XmlTag], e: &BytesText) {
     if !stack.is_empty() {
-        if let Ok(text) = e.decode() {
+        if let Ok(text) = e.unescape() {
             let t = text.trim();
             if !t.is_empty() {
                 if let Some(tag) = stack.last_mut() {


### PR DESCRIPTION
## Summary
- remove unused imports from the web index endpoint
- adapt the rate limiter layer to the latest tower-governor API
- switch XMLTV text handling to quick-xml's `unescape` helper

## Testing
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_e_68d2ded817c8832d8f905911fbd122f7