### PR TITLE
Clarify dependency summary in build tools bump workflow

### DIFF
--- a/.github/workflows/bump-tuliprox-build-tools.yml
+++ b/.github/workflows/bump-tuliprox-build-tools.yml
@@ -265,6 +265,7 @@ jobs:
               missing_entries.extend([{"file": path, "reason": "arg not found"} for path in missing_arg_candidates])
 
             updated_files = []
+            file_update_tracker = {}
             if latest_value and occurrences:
               needs_update = any(occ["value"] != latest_value for occ in occurrences)
               if needs_update:
@@ -279,6 +280,24 @@ jobs:
                     file_texts[path] = new_content
                     modified_files.add(path)
                     updated_files.append(path)
+                    file_update_tracker[path] = latest_value
+
+            details = []
+            seen_detail_files = set()
+            for occ in occurrences:
+              path = occ["file"]
+              if path in seen_detail_files:
+                continue
+              seen_detail_files.add(path)
+              previous = occ["value"]
+              new_value = file_update_tracker.get(path, previous)
+              details.append({
+                "file": path,
+                "arg": occ["arg"],
+                "previous": previous,
+                "new": new_value,
+                "updated": previous != new_value,
+              })
 
             changes[dep] = {
               "display": display,
@@ -287,6 +306,7 @@ jobs:
               "updated": bool(updated_files),
               "files": sorted({occ["file"] for occ in occurrences}),
               "updated_files": sorted(set(updated_files)),
+              "details": details,
               "missing": missing_entries,
             }
 
@@ -442,19 +462,45 @@ jobs:
             sections.append("- Unable to resolve rust metadata ❌")
 
           sections.append("\n### 📦 Dependency updates")
-          for key in ["RUST_DISTRO", "ALPINE_VERSION", "CARGO_CHEF_VER", "TRUNK_VER", "BINDGEN_VER"]:
+          dependency_order = ["RUST_DISTRO", "ALPINE_VERSION", "CARGO_CHEF_VER", "TRUNK_VER", "BINDGEN_VER"]
+          for key in dependency_order:
             info = changes.get(key)
             if not info:
               continue
-            icon = "⬆️" if info.get("updated") else "↔️"
+
             display = info.get("display", key)
             current = info.get("current") or "n/a"
             latest_val = info.get("latest") or "n/a"
-            sections.append(f"- {icon} {display}: `{current}` → `{latest_val}`")
+            files = info.get("files") or []
+
+            if info.get("updated"):
+              icon = "🆙"
+              header = f"- {icon} {display}: `{current}` → `{latest_val}`"
+            elif files:
+              icon = "✅"
+              header = f"- {icon} {display}: `{current}` (already latest)"
+            else:
+              icon = "❔"
+              header = f"- {icon} {display}: no tracked occurrences (latest `{latest_val}`)"
+
+            sections.append(header)
+
+            details = info.get("details") or []
+            for detail in details:
+              file_path = detail.get("file", "unknown")
+              previous = detail.get("previous") or "n/a"
+              new_value = detail.get("new") or previous
+              if detail.get("updated"):
+                file_icon = "✨"
+                line = f"  - {file_icon} `{file_path}`: `{previous}` → `{new_value}`"
+              else:
+                file_icon = "📄"
+                line = f"  - {file_icon} `{file_path}`: `{previous}` (unchanged)"
+              sections.append(line)
+
             missing = info.get("missing") or []
-            if missing:
-              warn_lines = [f"    - ⚠️ {entry['file']}: {entry['reason']}" for entry in missing]
-              sections.extend(warn_lines)
+            for entry in missing:
+              sections.append(f"  - ❗ {entry['file']}: {entry['reason']}")
 
           build_outcome = os.environ.get("BUILD_STATUS", "${{ steps.build.outcome }}")
           if build_outcome == "failure":


### PR DESCRIPTION
## Summary
- add per-file dependency metadata to the bump workflow outputs
- update the summary rendering to show detailed icons and file-by-file version changes

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68da5d2749a0832d9d88b0d04e23ab6f